### PR TITLE
Fix missing https:// in git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Ngrok will allow your local applications to be accessible from the public intern
 ## Validation
 
 ```bash
-git clone github.com/spring-loaded-bootcamp/workshop-prerequisites
+git clone https://github.com/spring-loaded-bootcamp/workshop-prerequisites
 cd workshop-prerequisites
 ```
 > Clone the repository and jump into the directory


### PR DESCRIPTION
## Summary
Fixed a minor typo in the README where the git clone command was missing the `https://` protocol.

## Changes
- Added `https://` to the git clone command in the validation section

## Testing
- Verified the corrected URL works properly for cloning the repository

This ensures users can successfully copy and paste the clone command without encountering protocol errors.